### PR TITLE
added red background color for root

### DIFF
--- a/powerline.zsh-theme
+++ b/powerline.zsh-theme
@@ -45,8 +45,13 @@ ZSH_THEME_GIT_PROMPT_RENAMED="%F{220]➜%f"
 ZSH_THEME_GIT_PROMPT_UNMERGED="%F{082]═%f"
 ZSH_THEME_GIT_PROMPT_UNTRACKED="%F{190]✭%f"
 
-POWERLINE_SEC1_BG=%K{green}
-POWERLINE_SEC1_FG=%F{green}
+if [ $(id -u) -eq 0 ]; then
+    POWERLINE_SEC1_BG=%K{red}
+    POWERLINE_SEC1_FG=%F{red}
+else
+    POWERLINE_SEC1_BG=%K{green}
+    POWERLINE_SEC1_FG=%F{green}
+fi
 POWERLINE_SEC1_TXT=%F{black}
 if [ "$POWERLINE_DETECT_SSH" != "" ]; then
   if [ -n "$SSH_CLIENT" ]; then


### PR DESCRIPTION
I use oh-my-zsh with powerline theme for normal user and root. When background color is the same in both cases it could be misleading. I know, that red background is used for ssh connections, but we can discuss it.
