### PR TITLE
New features in right prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,22 @@ By default, at the right of the powerline are displayed the date and the time.
 If you don't want date or time, you can choose what you want to display:
 
 ```
-POWERLINE_RIGHT="date replacement"
+POWERLINE_RIGHT_B="date replacement"
+```
+
+If you want to display date next to time:
+```
+POWERLINE_RIGHT_A="date"
+```
+
+If you want to display exit-code of last command next to time:
+```
+POWERLINE_RIGHT_A="exit-code"
+```
+
+If you want to display date or non-zero-exit-code of last command next to time:
+```
+POWERLINE_RIGHT_A="mixed"
 ```
 
 If you don't want to display your username (the green or red (root) colors are still there):

--- a/powerline.zsh-theme
+++ b/powerline.zsh-theme
@@ -1,7 +1,17 @@
 # FreeAgent puts the powerline style in zsh !
 
-if [ "$POWERLINE_RIGHT" = "" ]; then
-  POWERLINE_RIGHT=%D{%H:%M:%S}
+if [ "$POWERLINE_RIGHT_B" = "" ]; then
+  POWERLINE_RIGHT_B=%D{%H:%M:%S}
+fi
+
+if [ "$POWERLINE_RIGHT_A" = "mixed" ]; then
+  POWERLINE_RIGHT_A=%(?.%D{%d-%m}.%F{133}✘%?)
+elif [ "$POWERLINE_RIGHT_A" = "exit-status" ]; then
+  POWERLINE_RIGHT_A=%(?.%F{118}✔%?.%F{133}✘%?)
+elif [ "$POWERLINE_RIGHT_A" = "date" ]; then
+  POWERLINE_RIGHT_A=%D{%d-%m}
+else
+  POWERLINE_RIGHT_A=""
 fi
 
 if [ "$POWERLINE_HIDE_USER_NAME" = "" ]; then
@@ -99,4 +109,8 @@ if [ "$POWERLINE_NO_BLANK_LINE" = "" ]; then
 "$PROMPT
 fi
 
-RPROMPT="$POWERLINE_GIT_INFO_RIGHT%F{yellow}"$'\ue0b2'"%k%F{black}%K{yellow} $POWERLINE_RIGHT %f%k"
+if [ "$POWERLINE_RIGHT_A" = "" ]; then
+    RPROMPT="$POWERLINE_GIT_INFO_RIGHT%F{yellow}"$'\ue0b2'"%k%F{black}%K{yellow} $POWERLINE_RIGHT_B %f%k"
+else
+    RPROMPT="$POWERLINE_GIT_INFO_RIGHT%F{yellow}"$'\ue0b2'"%k%F{black}%K{yellow} $POWERLINE_RIGHT_B %f%F{240}"$'\ue0b2'"%f%k%K{240}%F{255} $POWERLINE_RIGHT_A %f%k"
+fi


### PR DESCRIPTION
I have updated README.md and added some features to the RPROMPT:
- <time<date `POWERLINE_RIGHT_A="date"`
- <time<exit-code-status+icon `POWERLINE_RIGHT_A="exit-status"`
- <time<mixed `POWERLINE_RIGHT_A="mixed"` <-- exit code status, if non-zero, or date
- <time `POWERLINE_RIGHT_A=""` <-- default

Variable `POWERLINE_RIGHT` changed to `POWERLINE_RIGHT_B`

What do You think?
