### PR TITLE
Added ability to hide username or hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ If you don't want to display your username (the green or red (root) colors are s
 POWERLINE_HIDE_USER_NAME="true"
 ```
 
+If you don't want to display your hostname (the green or red (root) colors are still there):
+
+```
+POWERLINE_HIDE_HOST_NAME="true"
+```
+
 If you don't want the blank line before the prompt:
 
 ```

--- a/powerline.zsh-theme
+++ b/powerline.zsh-theme
@@ -14,7 +14,11 @@ else
   POWERLINE_RIGHT_A=""
 fi
 
-if [ "$POWERLINE_HIDE_USER_NAME" = "" ]; then
+if [ "$POWERLINE_HIDE_USER_NAME" = "" ] && [ "$POWERLINE_HIDE_HOST_NAME" = "" ]; then
+    POWERLINE_USER_NAME="%n@%M"
+elif [ "$POWERLINE_HIDE_USER_NAME" != "" ] && [ "$POWERLINE_HIDE_HOST_NAME" = "" ]; then
+    POWERLINE_USER_NAME="@%M"
+elif [ "$POWERLINE_HIDE_USER_NAME" = "" ] && [ "$POWERLINE_HIDE_HOST_NAME" != "" ]; then
     POWERLINE_USER_NAME="%n"
 else
     POWERLINE_USER_NAME=""


### PR DESCRIPTION
I'm working in many hosts, so it's important to me, to be sure on which one I am at the moment. So there are 4 options controlled by `POWERLINE_HIDE_USER_NAME` and `POWERLINE_HIDE_HOST_NAME`:
1. user@hostname
2. @hostname
3. user
4. none
