### PR TITLE
added error message when install directory doesn't exist

### DIFF
--- a/install_in_omz.sh
+++ b/install_in_omz.sh
@@ -1,10 +1,12 @@
 #!/bin/sh
 
+if [ ! -d ~/.oh-my-zsh ]
+	then mkdir ~/.oh-my-zsh
+fi
+
 echo "Creating symlink from here to your oh-my-zsh themes path..."
 
-ln -f powerline.zsh-theme ~/.oh-my-zsh/themes/powerline.zsh-theme
-
-echo "
+successmsg="
 Done ! (the symlink is ~/.oh-my-zsh/themes/powerline.zsh-theme)
 
 ----------------------------------------------------------------------------------
@@ -19,3 +21,14 @@ Requirements:
 Vim Powerline patched font: See Powerline for vim for more info.
 Z shell (zsh): See oh-my-zsh for more info.
 Make sure terminal is using 256-colors mode with export TERM=\"xterm-256color\"".
+
+errormsg="
+Uh oh! Couldn't create symlink ~/.oh-my-zsh/themes/powerline.zsh-theme
+Check and see if you have permission to write to that directory."
+
+ln -f powerline.zsh-theme ~/.oh-my-zsh/themes/powerline.zsh-theme
+
+if [ $? = 0 ]
+	then echo "$successmsg"
+	else echo "$errormsg"
+fi


### PR DESCRIPTION
So I had trouble installing this, mainly because the script assumed ~/.oh-my-zsh existed. It didn't in my home directory, so I modified the script a little to make things a bit easier.
