### PR TITLE
Add rvm-prompt to the right hand side

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,12 @@ If you want to tell if you are in a remote SSH session:
 POWERLINE_DETECT_SSH="true"
 ```
 
+If you want to disable the RVM prompt
+
+```
+POWERLINE_DISABLE_RVM="true"
+```
+
 Also you can change the icons of GIT info, default values are:
 ```
 POWERLINE_GIT_CLEAN="✔"

--- a/powerline.zsh-theme
+++ b/powerline.zsh-theme
@@ -1,6 +1,6 @@
 # FreeAgent puts the powerline style in zsh !
 
-if [ $POWERLINE_DISABLE_RVM = "true" ]; then
+if [ "$POWERLINE_DISABLE_RVM" = "true" ]; then
   POWERLINE_RVM_PROMPT=""
 else
   POWERLINE_RVM_PROMPT="%F{240}"$'\ue0b2'"%K{240}%F{white}"' $(rvm-prompt)%K{240} '

--- a/powerline.zsh-theme
+++ b/powerline.zsh-theme
@@ -1,5 +1,11 @@
 # FreeAgent puts the powerline style in zsh !
 
+if [ $POWERLINE_DISABLE_RVM = "true" ]; then
+  POWERLINE_RVM_PROMPT=""
+else
+  POWERLINE_RVM_PROMPT="%F{240}"$'\ue0b2'"%K{240}%F{white}"' $(rvm-prompt)%K{240} '
+fi
+
 if [ "$POWERLINE_DATE_FORMAT" = "" ]; then
   POWERLINE_DATE_FORMAT=%D{%Y-%m-%d}
 fi
@@ -122,10 +128,10 @@ fi
 
 if [ "$POWERLINE_DISABLE_RPROMPT" = "" ]; then
     if [ "$POWERLINE_RIGHT_A" = "" ]; then
-        RPROMPT="$POWERLINE_GIT_INFO_RIGHT%F{white}"$'\ue0b2'"%k%F{black}%K{white} $POWERLINE_RIGHT_B %f%k"
+        RPROMPT="$POWERLINE_RVM_PROMPT""$POWERLINE_GIT_INFO_RIGHT%F{white}"$'\ue0b2'"%k%F{black}%K{white} $POWERLINE_RIGHT_B %f%k"
     elif [ "$POWERLINE_RIGHT_B" = "" ]; then
-        RPROMPT="$POWERLINE_GIT_INFO_RIGHT%F{white}"$'\ue0b2'"%k%F{240}%K{white} $POWERLINE_RIGHT_A %f%k"
+        RPROMPT="$POWERLINE_RVM_PROMPT""$POWERLINE_GIT_INFO_RIGHT%F{white}"$'\ue0b2'"%k%F{240}%K{white} $POWERLINE_RIGHT_A %f%k"
     else
-        RPROMPT="$POWERLINE_GIT_INFO_RIGHT%F{white}"$'\ue0b2'"%k%F{black}%K{white} $POWERLINE_RIGHT_B %f%F{240}"$'\ue0b2'"%f%k%K{240}%F{255} $POWERLINE_RIGHT_A %f%k"
+        RPROMPT="$POWERLINE_RVM_PROMPT""$POWERLINE_GIT_INFO_RIGHT%F{white}"$'\ue0b2'"%k%F{black}%K{white} $POWERLINE_RIGHT_B %f%F{240}"$'\ue0b2'"%f%k%K{240}%F{255} $POWERLINE_RIGHT_A %f%k"
     fi
 fi


### PR DESCRIPTION
Hello, these changes add the output of 'rvm-prompt' to the right hand side of the prompt.  The user can disable rvm-prompt by adding POWERLINE_DISABLE_RVM='true' to .zshrc.