### PR TITLE
Add exit-status-on-fail option

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ If you want to display exit-code of last command next to time:
 ```
 POWERLINE_RIGHT_A="exit-status"
 ```
+or if you want it to appear only on faulty runs:
+```
+POWERLINE_RIGHT_A="exit-status-on-fail"
+```
 
 If you want to display date or non-zero-exit-code of last command next to time:
 ```

--- a/powerline.zsh-theme
+++ b/powerline.zsh-theme
@@ -14,6 +14,8 @@ if [ "$POWERLINE_RIGHT_A" = "mixed" ]; then
   POWERLINE_RIGHT_A=%(?."$POWERLINE_DATE_FORMAT".%F{red}✘ %?)
 elif [ "$POWERLINE_RIGHT_A" = "exit-status" ]; then
   POWERLINE_RIGHT_A=%(?.%F{green}✔ %?.%F{red}✘ %?)
+elif [ "$POWERLINE_RIGHT_A" = "exit-status-on-fail" ]; then
+  POWERLINE_RIGHT_A=%(?..%F{red}✘ %?)
 elif [ "$POWERLINE_RIGHT_A" = "date" ]; then
   POWERLINE_RIGHT_A="$POWERLINE_DATE_FORMAT"
 fi


### PR DESCRIPTION
Allows exit-status to appear only on faulty runs